### PR TITLE
Fix client file inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,9 @@ A nice base for GMod gamemodes.
 - Basic HUD setup that hides default HL2 HUD elements. (client/cl_hud.lua)
 
 # Usage
-Change the variable 'gamemodeFolderName' in init.lua and cl_init.lua to the name of your gamemode's folder, then your ready to go!
+Rename the folder "alydusbase" to your new gamemode name. New files should be created within client, server, shared, or auto folders with the appropriate prefix. For example:
+
+  * client/cl_hud.lua
+  * server/sv_test.lua
+  * shared/sh_template.lua
+  * auto/cl_example.lua

--- a/alydusbase/gamemode/init.lua
+++ b/alydusbase/gamemode/init.lua
@@ -74,7 +74,7 @@ for k,v in pairs(clientDirectories) do
 end
 
 for k,v in pairs(file.Find(gamemodeFolderName .. "/gamemode/client/cl_*.lua", "LUA")) do
-	include("client/" .. v)
+	AddCSLuaFile("client/" .. v)
 	if doConsoleMessages then
 		print("Making 'client/" .. v .. "' avaliable for client in init.lua")
 	end


### PR DESCRIPTION
An error on line 77 caused client files to be executed on the server, instead of being sent to the client. Client files not included in a subdirectory of alydusbase/client would otherwise not be sent to clients.

Additionally updated README.md to reflect changes in the latest version + added file naming examples.