### PR TITLE
Solution for dynamic naming

### DIFF
--- a/alydusbase/gamemode/cl_init.lua
+++ b/alydusbase/gamemode/cl_init.lua
@@ -2,7 +2,7 @@ include("shared.lua")
 
 // Variables
 local doConsoleMessages = true // Show include information on init?
-local gamemodeFolderName = "alydusbase" // The gamemode folder name (do not use engine.ActiveGamemode)
+local gamemodeFolderName = GM.FolderName //Automagically retrieve gamemode name
 
 local clientFiles, clientDirectories = file.Find(gamemodeFolderName .. "/gamemode/client/*", "LUA")
 local sharedFiles, sharedDirectories = file.Find(gamemodeFolderName .. "/gamemode/shared/*", "LUA")

--- a/alydusbase/gamemode/init.lua
+++ b/alydusbase/gamemode/init.lua
@@ -5,7 +5,7 @@ include("shared.lua")
 
 // Variables
 local doConsoleMessages = true // Show include information on init?
-local gamemodeFolderName = "alydusbase" // The gamemode folder name (do not use engine.ActiveGamemode)
+local gamemodeFolderName = GM.FolderName //Automagically retrieves gamemode name
 
 local clientFiles, clientDirectories = file.Find(gamemodeFolderName .. "/gamemode/client/*", "LUA")
 local sharedFiles, sharedDirectories = file.Find(gamemodeFolderName .. "/gamemode/shared/*", "LUA")


### PR DESCRIPTION
This pull request finally solves dynamic gamemode naming. Instead of hard coding the gamemode name, it is now detected automatically. No conflicts are created during client initialization.

Previously, gamemode name was determined by engine.ActiveGamemode(). During client initialization, engine.ActiveGamemode() will return "base" while it loads files, which causes file inclusion to fail on the client. Attempting to delay the inclusion until engine.ActiveGamemode() returns the correct gamemode causes conflicts with client file inclusion.

The solution proposed utilizes GM.FolderName, which appears to have the correct value at all periods of runtime.
